### PR TITLE
Allow linter failure on warnings to be configured

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ sudo: false
 dist: trusty
 language: generic
 env:
-- PDK=release
-- PDK=nightly
+  - PDK=release PDK_FRONTEND=noninteractive
+  - PDK=nightly PDK_FRONTEND=noninteractive
 before_install:
-- ".travis/install_pdk.sh"
+  - ".travis/install_pdk.sh"
 script:
-- ".travis/test_script.sh"
+  - ".travis/test_script.sh"
 branches:
   only:
-  - master
+    - master
 notifications:
   email: false
   slack:

--- a/.travis/install_pdk.sh
+++ b/.travis/install_pdk.sh
@@ -25,9 +25,6 @@ main() {
     sudo apt-get update -qq
     sudo apt-get install -y pdk
 
-    mkdir -p ~/.config/puppet
-    echo "---\ndisabled: true" > ~/.config/puppet/analytics.yml
-
     /usr/local/bin/pdk --version
 }
 

--- a/.travis/install_pdk.sh
+++ b/.travis/install_pdk.sh
@@ -25,6 +25,9 @@ main() {
     sudo apt-get update -qq
     sudo apt-get install -y pdk
 
+    mkdir -p ~/.config/puppet
+    echo "---\ndisabled: true" > ~/.config/puppet/analytics.yml
+
     /usr/local/bin/pdk --version
 }
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |extra\_disabled\_lint\_checks| Defines any checks that are to be disabled as extras when running lint checks. No defaults are defined for this configuration. _Does affect **.puppet-lint.rc**._ |
 |extras|An array of extra lines to add into your Rakefile. As an alternative you can add a directory named `rakelib` to your module and files in that directory that end in `.rake` would be loaded by the Rakefile.|
 |linter\_options| An array of options to be passed into linter config. _Does affect **.puppet-lint.rc**._ |
+|linter\_fail\_on\_warnings| A boolean indicating if the linter should exit non-zero on warnings as well as failures. _Does affect **.puppet-lint.rc**._ |
 
 ### .rubocop.yml
 

--- a/moduleroot/.puppet-lint.rc.erb
+++ b/moduleroot/.puppet-lint.rc.erb
@@ -6,11 +6,16 @@
       rakefile_config['extra_disabled_lint_checks'].to_a,
     ].flatten.uniq
     options = rakefile_config['linter_options'].to_a
+    fail_on_warnings = rakefile_config['linter_fail_on_warnings']
   else
     disabled_checks = []
     options = []
+    fail_on_warnings = false
   end
 -%>
+<% if fail_on_warnings -%>
+--fail-on-warnings
+<% end -%>
 <% disabled_checks.each do |check_name| -%>
 <%- if check_name == 'relative' -%>
 --relative

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -54,6 +54,9 @@ end
 <% checks.each do |check| -%>
 PuppetLint.configuration.send('disable_<%= check %>')
 <% end -%>
+<% if @configs['linter_fail_on_warnings'] -%>
+PuppetLint.configuration.fail_on_warnings = true
+<% end -%>
 <% linter_options =  @configs['linter_options'] || [] -%>
 <% linter_options.each do |option| -%>
 PuppetLint.configuration.send('<%= option %>')


### PR DESCRIPTION
Add 'linter_fail_on_warnings' option to configure puppet lint
to return a failure code for all warnings as well as failure
conditions.