### PR TITLE
Disable PDK analytics in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ sudo: false
 dist: trusty
 language: generic
 env:
-- PDK=release
-- PDK=nightly
+  global:
+    - PDK_DISABLE_ANALYTICS=1
+  matrix:
+    - PDK=release
+    - PDK=nightly
 before_install:
 - ".travis/install_pdk.sh"
 script:


### PR DESCRIPTION
The recently introduced PDK analytics feature prompts for user
consent on first invocation which is preventing the Travis CI
job from completing successfully on those PDK builds. This
will ensure that PDK analytics are always disabled.