### PR TITLE
Fix GitLab CI empty custom job parameter handling

### DIFF
--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -119,7 +119,9 @@ beaker:
 <%   configs['custom_jobs'].each do |job, params| -%>
 <%= job %>:
 <%     params.each do |param, config| -%>
-<%       if config.is_a?(Array) -%>
+<%       if (config.is_a?(Array) || config.is_a?(Hash)) && config.empty? -%>
+  <%= param %>: <%= config.inspect %>
+<%       elsif config.is_a?(Array) -%>
   <%= param %>:
 <%         config.each do |element| -%>
     - <%= element %>
@@ -128,9 +130,13 @@ beaker:
   <%= param %>:
 <%         config.each do |element, value| -%>
 <%           if value.is_a?(Array) -%>
+<%             if value.empty? -%>
+    <%= element %>: <%= value.inspect %>
+<%             else -%>
     <%= element %>:
-<%             value.each do |content| -%>
+<%               value.each do |content| -%>
       - <%= content %>
+<%               end -%>
 <%             end -%>
 <%           else -%>
     <%= element %>: '<%= value %>'


### PR DESCRIPTION
When generating GitLab CI configuration containing custom jobs
with parameters consisting of empty arrays or hashes, correctly
generate the .gitlab-ci.yml with those empty types.